### PR TITLE
feat(menu): reintroduce app menu (preferences/refresh)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -69,7 +69,7 @@ fn main() {
                 }
                 "quit" => {
                     // Graceful app exit
-                    let _ = app.exit(0);
+                    app.exit(0);
                 }
                 _ => {}
             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ use api::{
     clear_instances_cache, clear_token, fetch_instances, fetch_languages, save_token, test_token,
     token_status, AppState,
 };
+use tauri::{menu::{Menu, MenuItem, Submenu}, Emitter, Manager};
 
 fn main() {
     tauri::Builder::default()
@@ -21,6 +22,58 @@ fn main() {
             fetch_languages,
             clear_instances_cache
         ])
+        .menu(|app| {
+            // Build a minimal cross-platform menu (Tauri 2 API)
+            let menu = Menu::new(app)?;
+
+            let preferences = MenuItem::with_id(
+                app,
+                "preferences",
+                "Préférences…",
+                true,
+                if cfg!(target_os = "macos") { Some("Cmd+,") } else { Some("Ctrl+,") },
+            )?;
+            let refresh = MenuItem::with_id(
+                app,
+                "refresh",
+                "Actualiser",
+                true,
+                if cfg!(target_os = "macos") { Some("Cmd+R") } else { Some("Ctrl+R") },
+            )?;
+
+            let file = Submenu::new(app, "Fichier", true)?;
+            file.append(&preferences)?;
+            // A simple Quit item (without platform-specific predefined helpers)
+            let quit = MenuItem::with_id::<_, _, _, &str>(app, "quit", "Quitter", true, None)?;
+            file.append(&quit)?;
+            menu.append(&file)?;
+
+            let view = Submenu::new(app, "Affichage", true)?;
+            view.append(&refresh)?;
+            menu.append(&view)?;
+
+            Ok(menu)
+        })
+        .on_menu_event(|app, event| {
+            let id = event.id.as_ref();
+            match id {
+                "preferences" => {
+                    for w in app.webview_windows().values() {
+                        let _ = w.emit("menu://preferences", serde_json::json!({}));
+                    }
+                }
+                "refresh" => {
+                    for w in app.webview_windows().values() {
+                        let _ = w.emit("menu://refresh", serde_json::json!({}));
+                    }
+                }
+                "quit" => {
+                    // Graceful app exit
+                    let _ = app.exit(0);
+                }
+                _ => {}
+            }
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
- Tauri 2 menu reintroduced: Fichier (Préférences…, Quitter), Affichage (Actualiser)
- Emits "menu://preferences" and "menu://refresh" to the webview
- Cross-platform accelerators (macOS/others)