### PR TITLE
ci: auto-enable auto-merge for Dependabot minor/patch groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,24 +3,55 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
+      time: '04:00'
+      timezone: 'Europe/Paris'
     open-pull-requests-limit: 5
     groups:
+      # Group all @typescript-eslint/* updates together
       ts-eslint:
         patterns:
           - '@typescript-eslint/*'
+      # Group other updates by type
+      npm-minor-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+      npm-majors:
+        update-types:
+          - 'major'
 
   - package-ecosystem: 'cargo'
     directory: '/src-tauri'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
+      time: '04:00'
+      timezone: 'Europe/Paris'
     open-pull-requests-limit: 5
+    groups:
+      rust-minor-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+      rust-majors:
+        update-types:
+          - 'major'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
+      time: '04:00'
+      timezone: 'Europe/Paris'
     open-pull-requests-limit: 5
     commit-message:
       prefix: 'ci'
       include: 'scope'
+    groups:
+      gha-minor-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+      gha-majors:
+        update-types:
+          - 'major'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       time: '04:00'
       timezone: 'Europe/Paris'
     open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - npm
     groups:
       # Group all @typescript-eslint/* updates together
       ts-eslint:
@@ -28,6 +31,10 @@ updates:
       time: '04:00'
       timezone: 'Europe/Paris'
     open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - rust
+      - cargo
     groups:
       rust-minor-patch:
         update-types:
@@ -44,6 +51,10 @@ updates:
       time: '04:00'
       timezone: 'Europe/Paris'
     open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+      - ci
     commit-message:
       prefix: 'ci'
       include: 'scope'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Forbid forbidden Unicode punctuation
         shell: bash
         run: bash scripts/check-forbidden-unicode.sh
-      
+
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,16 +18,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - name: Prepare Tauri dist dir (stub)
-        if: steps.changes.outputs.docs_only != 'true'
-        run: |
-          # Tauri's generate_context!() requires distDir to exist at compile-time.
-          # Create a minimal stub so Clippy can compile src-tauri without building the web app.
-          mkdir -p dist
-          test -f dist/index.html || echo "<!doctype html><title>stub</title>" > dist/index.html
-      - name: Forbid forbidden Unicode punctuation
-        shell: bash
-        run: bash scripts/check-forbidden-unicode.sh
       - name: Detect docs-only changes
         id: changes
         shell: bash
@@ -54,6 +44,17 @@ jobs:
             echo "docs_only=true" >> "$GITHUB_OUTPUT"
           fi
           echo "files_changed=true" >> "$GITHUB_OUTPUT"
+      - name: Prepare Tauri dist dir (stub)
+        if: steps.changes.outputs.docs_only != 'true'
+        run: |
+          # Tauri's generate_context!() requires distDir to exist at compile-time.
+          # Create a minimal stub so Clippy can compile src-tauri without building the web app.
+          mkdir -p dist
+          test -f dist/index.html || echo "<!doctype html><title>stub</title>" > dist/index.html
+      - name: Forbid forbidden Unicode punctuation
+        shell: bash
+        run: bash scripts/check-forbidden-unicode.sh
+      
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
@@ -98,35 +99,50 @@ jobs:
   linux-appimage:
     runs-on: ubuntu-24.04
     needs: [checks]
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
+      - name: Context
+        run: echo "ref=${{ github.ref }}"
+      - name: Not a release tag (noop)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: echo "Not a v* tag; skipping AppImage build."
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Install system deps (Tauri)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           set -euxo pipefail
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev \
             libsoup-3.0-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev
       - name: Install JS deps
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: npm ci || npm install
       - name: Build xtask (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: cargo build --manifest-path xtask/Cargo.toml --release
       - name: Build AppImage (xtask)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: ./xtask/target/release/xtask build appimage
       - name: Build Debian package (xtask)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: ./xtask/target/release/xtask build deb
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           name: appimage
           path: src-tauri/target/release/bundle/appimage/*.AppImage
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           name: deb
           path: src-tauri/target/release/bundle/deb/*.deb
@@ -134,23 +150,35 @@ jobs:
   windows-nsis:
     runs-on: windows-latest
     needs: [checks]
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
+      - name: Context
+        run: echo "ref=${{ github.ref }}"
+      - name: Not a release tag (noop)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: echo "Not a v* tag; skipping Windows NSIS build."
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Install JS deps
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: npm ci || npm install
       - name: Build xtask (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: cargo build --manifest-path xtask/Cargo.toml --release
       - name: Build NSIS installer (xtask)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: .\\xtask\\target\\release\\xtask.exe build win-nsis
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           name: windows-nsis
           path: src-tauri/target/release/bundle/nsis/*.exe

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,44 @@
+name: dependabot-auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide auto-merge eligibility
+        id: decide
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          echo "head=$HEAD_REF"
+          echo "title=$TITLE"
+          ok="false"
+          case "$HEAD_REF" in
+            *-minor-patch-*) ok="true" ;;
+            *-minor-patch) ok="true" ;;
+            *minor-patch*) ok="true" ;;
+          esac
+          # Fallback heuristic on title if needed
+          if [[ "$ok" != "true" ]]; then
+            if echo "$TITLE" | grep -iqE '\bminor\b|\bpatch\b' && ! echo "$TITLE" | grep -iqE '\bmajor\b'; then
+              ok="true"
+            fi
+          fi
+          echo "ok=$ok" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge (squash)
+        if: steps.decide.outputs.ok == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} --auto --squash


### PR DESCRIPTION
Automates auto-merge (squash) for Dependabot PRs that belong to our *-minor-patch groups.\n\n- Trigger: pull_request_target (Dependabot only)\n- Logic: enable auto-merge when head ref or PR title indicates minor/patch group; majors are excluded.\n- Permissions: minimal (contents+pull-requests: write).\n\nThis keeps majors for manual review while merging safe updates automatically.