### PR TITLE
chore(ci): checkout repository befor running gh

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -36,6 +36,11 @@ jobs:
           fi
           echo "ok=$ok" >> "$GITHUB_OUTPUT"
 
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+        if: steps.decide.outputs.ok == 'true'
+
       - name: Enable auto-merge (squash)
         if: steps.decide.outputs.ok == 'true'
         env:


### PR DESCRIPTION
## Summary

Check out the repository before setting auto-merge for Dependabot pull requests

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [x] build/ci/chore

## Checklist

- [ ] `make ci-checks` passes (ESLint, tsc --noEmit, Prettier, Clippy, rustfmt)
- [ ] Manual a11y sanity check (keyboard navigation, focus visible, announcements)
- [x] No forbidden Unicode (U+2011, U+00A0, U+2212)
- [ ] Docs updated if needed (README/CONTRIBUTING)
- [ ] Screenshots (UI changes)

## Test Steps

Non applicable
